### PR TITLE
explicitly specify integration test location

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,8 @@ provisioner:
 
 verifier:
   name: inspec
+  inspec_tests:
+    - test/smoke/default
 
 platforms:
   - name: centos-7


### PR DESCRIPTION
The inspec tests for this cookbook are in `test/smoke/default`, but at least some versions of Test Kitchen and/or kitchen-inspec (I'm running 2.1.72 and 0.23.1 respectively) look to `test/integration/default` by default.  A small change to `.kitchen.yml` will direct Test Kitchen to the actual location regardless of what versions are being used.  If this was deliberate with the intent that it be fixed in one of the Chef Rally modules as a learning experience then feel free to close with no action.

Signed-off-by: Mike Stevenson <Mike.Stevenson@us.logicalis.com>