### PR TITLE
CHEF-25322 - quick-archive - added archive note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Archived Repository
+This repository has been archived and will no longer receive updates. 
+It was archived as part of the [Repository Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025).
+If you are a Chef customer and need support for this repository, please contact your Chef account team.
+
+---
+
 # learn_chef_httpd
 
 This basic cookbook configures Apache on Red Hat Enterprise Linux.


### PR DESCRIPTION
This PR adds an archive notice to the top of the README.md to indicate that this repository is no longer maintained and has been archived as part of the Repository Standardization Initiative.